### PR TITLE
Allow custom pagesize

### DIFF
--- a/src/LosPdf/View/Renderer/MpdfRenderer.php
+++ b/src/LosPdf/View/Renderer/MpdfRenderer.php
@@ -26,11 +26,13 @@ final class MpdfRenderer extends AbstractRenderer
         $paperOrientation = $this->getOption('paperOrientation', 'portrait');
         $paperSize = $this->getOption('paperSize', 'a4');
 
-        $format = strtolower($paperOrientation[0]);
-        if ($format == 'l') {
-            $paperSize = $paperSize.'-'.$format;
+        if (!is_array($paperSize)) {
+            $format = strtolower($paperOrientation[0]);
+            if ($format == 'l') {
+                $paperSize = $paperSize.'-'.$format;
+            }
         }
-
+        
         $this->getEngine()->_setPageSize($paperSize, $paperOrientation);
         $this->getEngine()->WriteHTML($this->html);
     }


### PR DESCRIPTION
mPDF allow for custom pagesizes. They are passed as an array of width/height as the pagesize. 
This change allows for arrays to be passed as pagesize.
